### PR TITLE
Changed minimum-stability to dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
             "dev-master": "1.0-dev"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true
 }


### PR DESCRIPTION
This should allow users to install the package now on ` > 5.4`.
Not 100% @gutdev could test it on his install.

Fixes #3 #2 