### PR TITLE
 Fix: Select statements being overriden by distance and geofence functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,19 @@ protected static $kilometers = true;
 ### Notes
 
 1. The method returns a `Eloquent\Builder` object so that you can add optional conditions if you want.
-2. You can use `distance` as an aggregate column in the result.
+2. If you require to select only a certain columns, it can be achieved by using `select()`.
+    ```php
+    Model::select('id', 'name')->distance($latitude, $longitude);
+    ```
+    (`select()` should precede the `distance()/geofence()`)
+3. You can use `distance` as an aggregate column in the result.
 (Aggregate columns cannot be used in `WHERE`, use `HAVING` to execute any condition.)
-3. If you use different column names for latitude and longitude, mention them in the Model.php
-```php
-const LATITUDE  = 'lat';
-const LONGITUDE = 'lng';
-```
+4. If you use different column names for latitude and longitude, mention them in the Model.php
+    ```php
+    const LATITUDE  = 'lat';
+    const LONGITUDE = 'lng';
+    ```
+
 
 ## Installation
 

--- a/src/Geographical.php
+++ b/src/Geographical.php
@@ -22,7 +22,14 @@ trait Geographical
     {
         $latName = $this->getQualifiedLatitudeColumn();
         $lonName = $this->getQualifiedLongitudeColumn();
-        $query->select($this->getTable() . '.*');
+
+        // Adding already selected columns to query, all columns will be selected by default
+        if ($query->getQuery()->columns === null) {
+            $query->select($this->getTable() . '.*');
+        } else {
+            $query->select($query->getQuery()->columns);
+        }
+
         $sql = "((ACOS(SIN(? * PI() / 180) * SIN(" . $latName . " * PI() / 180) + COS(? * PI() / 180) * COS(" .
             $latName . " * PI() / 180) * COS((? - " . $lonName . ") * PI() / 180)) * 180 / PI()) * 60 * ?) as distance";
 


### PR DESCRIPTION
Addressing issue #10 this will fix users to select their own columns before calling the distance method. Also updated documentation to reflect the ability.