### PR TITLE
Allowing ability to only obtain distance column of model

### DIFF
--- a/src/Geographical.php
+++ b/src/Geographical.php
@@ -23,10 +23,10 @@ trait Geographical
         $latName = $this->getQualifiedLatitudeColumn();
         $lonName = $this->getQualifiedLongitudeColumn();
 
-        $allowEmptyColumns = ( property_exists(static::class, 'allow_empty_columns') ) ? static::$allow_empty_columns : false;
+        $allowSelectedColumnsToBeEmpty = ( property_exists(static::class, 'allow_selected_columns_to_be_empty') ) ? static::$allow_selected_columns_to_be_empty : false;
 
         // All columns will be selected by default if we are not allowing empty columns
-        if ( ! $allowEmptyColumns && $query->getQuery()->columns === null )
+        if ( ! $allowSelectedColumnsToBeEmpty && $query->getQuery()->columns === null )
         {
             $query->select($this->getTable() . '.*');
         }

--- a/src/Geographical.php
+++ b/src/Geographical.php
@@ -23,10 +23,17 @@ trait Geographical
         $latName = $this->getQualifiedLatitudeColumn();
         $lonName = $this->getQualifiedLongitudeColumn();
 
-        // Adding already selected columns to query, all columns will be selected by default
-        if ($query->getQuery()->columns === null) {
+        $allowEmptyColumns = ( property_exists(static::class, 'allow_empty_columns') ) ? static::$allow_empty_columns : false;
+
+        // All columns will be selected by default if we are not allowing empty columns
+        if ( ! $allowEmptyColumns && $query->getQuery()->columns === null )
+        {
             $query->select($this->getTable() . '.*');
-        } else {
+        }
+        
+        // Adding already selected columns to query
+        if ( $query->getQuery()->columns )
+        {
             $query->select($query->getQuery()->columns);
         }
 


### PR DESCRIPTION
This pull request allows users of this package to specify whether requests to the `distance` scope will automatically add columns to the query or not.

All a user would have to do is apply 

```php
protected static $allow_selected_columns_to_be_empty = true;
```

on their model and the default behavior will not add columns to the query. The user must specify the columns that they want in the query, for example:

```php
$models = Geographical::select('*')->distance();
```

### Reasoning

I worked with this package but needed to sort an `Employee` model by a `Location` model's distance parameter. `Location` has a defined relationship with `Employee` model. The query I was eventually able to use looked like this

```php
$ordering_subquery = Location::distance($latitude, $longitude)->whereColumn('id', 'hr_employee.workAddress')->limit(1);

$query->whereHas('employeeLocation', function (Builder $query) use ($latitude, $longitude, $filter_distance) {
    $query->distance($latitude,` $longitude)->having('distance', '<=', $filter_distance ?? PHP_INT_MAX);
})->orderBy( $ordering_subquery, 'asc');
```

Where `employeeLocation` is the name ofthe relationship (for reasons). `Location` is the model with the `Geographical::distance()` scope.