### PR TITLE
Add support for joined tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,35 @@ protected static $kilometers = true;
     const LONGITUDE = 'lng';
     ```
 
+### Options
 
+1. You may pass an array of options as the third parameter of the distance method, these options will allow you to set a new table name or column names at runtime.
+     ```php
+    $query = Model::distance($latitude, $longitude, $options);
+    ```
+
+2. There are three fields you set with the options parameter at runtime: table, latitude_column, and longitude_column:
+    ```php
+    $options = [
+       'table' => 'coordinates',
+       'latitude_column' => 'lat',
+       'longitude_column' => 'lon'
+    ]
+   
+    Model::select('id', 'name')->distance($latitude, $longitude, $options);
+    ```
+3. The table field will allow you to set the table from which the the coordinates will be selected at runtime, allowing you to join the coordinates to your model from another table.
+    ```php
+   
+   Model::join('locations', function($join){ 
+               $join->on('model.id', '=', 'locations.model_id');
+           })
+           ->select('id', 'name')
+           ->distance($latitude, $longitude, ['table' => 'locations']);
+    ```
+4. The latitude_column and longitude_column fields can be used to set the column names for a joined table, or to override the default column names (including those set on your model) at runtime. If you don't set the column name fields at runtime when using a joined table then column names set on your model, or the defaults of 'latitude' and 'longitude' will be used. Setting `const LATITUDE  = 'lat'` or `const LONGITUDE = 'lng'` on a joined model will have no effect.
+                                                                                                                                                                                                     
+ 
 ## Installation
 
 [PHP](https://php.net) 5.6.4+ and [Laravel](http://laravel.com) 5+ are required.


### PR DESCRIPTION
Added support for joined tables, such as in my use case where I have a restaurant model with multiple locations, and want to query against the restaurants model with the locations joined in. This is done by adding an optional array as a third parameter to the distance method, which allows you to set the table name and the column names to use (which may be skipped in favor of the defaults). 